### PR TITLE
Fix problem loading data from default location.

### DIFF
--- a/lib/static_model/base.rb
+++ b/lib/static_model/base.rb
@@ -194,7 +194,7 @@ module StaticModel
 
       protected
       def default_data_file_path
-        File.join(self.class.load_path, "#{self.to_s.tableize}.yml")
+        File.join(self.load_path, "#{self.to_s.tableize}.yml")
       end
 
       private


### PR DESCRIPTION
This is my first time using github, and my first time using Ruby, so I'll start by apologizing for anything and everything, just in case.  :)

I was having trouble reading data without explicitly calling set_data_file.  I tracked the bug back to a recent submission.  Because default_data_file_path() is in the Base singleton, 'self' already refers to the class.

This seems to have fixed it for me, hopefully it was the correct approach.

Thanks for the library.
